### PR TITLE
Use circleci/jira@2.0.2

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,4 +8,4 @@ display:
   source_url: "https://github.com/flowerpress/circleci-jira-flowerpress-orb"
 
 orbs:
-  jira: fpcs/jira@2.0.2
+  jira: circleci/jira@2.0.2


### PR DESCRIPTION
[Upstream orb merged my PR and made a release](https://github.com/CircleCI-Public/jira-orb/releases/tag/v2.0.2), so this PR switches back to using that instead of our fork of the orb.